### PR TITLE
Produce warning, not abort, when using Ruby 1.9

### DIFF
--- a/lib/faster_csv.rb
+++ b/lib/faster_csv.rb
@@ -8,7 +8,7 @@
 # See FasterCSV for documentation.
 
 if RUBY_VERSION >= "1.9"
-  abort <<-VERSION_WARNING.gsub(/^\s+/, "")
+  warn <<-VERSION_WARNING.gsub(/^\s+/, "")
   Please switch to Ruby 1.9's standard CSV library.  It's FasterCSV plus
   support for Ruby 1.9's m17n encoding engine.
   VERSION_WARNING


### PR DESCRIPTION
Using `abort` is extremely frustrating as the presence of this library in an application will prevent the entire application from loading even if it's a non-critical component. Encouraging people to upgrade is one thing, but holding their entire application hostage is really not nice.
