### PR TITLE
Remove mention of deleted setup.rb from Rakefile 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,7 +61,7 @@ spec = Gem::Specification.new do |spec|
 	                           reject { |item| item.include?(".svn") } +
 	                       Dir.glob("{test,examples}/**/*.csv").
 	                           reject { |item| item.include?(".svn") } +
-	                       %w[Rakefile setup.rb test/line_endings.gz]
+	                       %w[Rakefile test/line_endings.gz]
 
 	spec.has_rdoc         = true
 	spec.extra_rdoc_files = %w[ AUTHORS COPYING README INSTALL TODO CHANGELOG


### PR DESCRIPTION
This fixes a problem where some Rake targets (like 'rake package')
would abort with the error "Don't know how to build task 'setup.rb'"

Please let me know if you would rather I file a bug for this on RubyForge.
