### PR TITLE
Document that :return_headers should be set along with :write_headers to output headers from a header-only table

### DIFF
--- a/lib/faster_csv.rb
+++ b/lib/faster_csv.rb
@@ -1402,6 +1402,10 @@ else
     #                                       through the converters).
     # <b><tt>:write_headers</tt></b>::      When +true+ and <tt>:headers</tt> is
     #                                       set, a header row will be added to the
+    #                                       output. Note that if the table only
+    #                                       contains header rows,
+    #                                       <tt>:return_headers</tt> must also be
+    #                                       set in order for a header row to be
     #                                       output.
     # <b><tt>:header_converters</tt></b>::  Identical in functionality to
     #                                       <tt>:converters</tt> save that the


### PR DESCRIPTION
As James Gray pointed out in
http://rubyforge.org/tracker/index.php?func=detail&aid=29111&group_id=1102&atid=4335
, a table that only contains header rows must have :return_headers set
in order for :write_headers to write a header row.

This is now explicitly documented.
